### PR TITLE
add openassets executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,25 @@ Creates a transaction for sending **multiple** asset from the open asset address
   tx = api.send_assets(from, params)
   ``` 
 
+
+## Command line interface
+
+Openassets-ruby comes with a `openassets` command line interface that allows easy interaction with OpenAssets. 
+
+### Usage
+
+    openassets [options] [command]
+    
+    Options: 
+    -c path to config JSON which is passed to OpenAssets::Api.new - see Configuration for details
+    -e load conifg from ENV variables (look at the exe/openassets file for details) 
+
+    commands:
+    * console runs an IRB console and gives you an initialized Api instance to interact with OpenAssets
+    * any method on the API instance, helpful for get_balance, list_unspent
+
+
+
 ## License
 
 The MIT License (MIT)

--- a/exe/openassets
+++ b/exe/openassets
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "openassets"
+require 'optparse'
+require 'json'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: openassets [options] [command]"
+
+  opts.on("-c PATH", "--config PATH", "config load path") do |path|
+    options[:config] = path
+  end
+  opts.on("-e", "--env", "load config from ENV variablse") do |env|
+    options[:env] = env
+  end
+  opts.on("-v", "--verbose", "verbose output") do |v|
+    options[:verbose] = v
+  end
+end.parse!
+
+puts "Welcome to OpenAssets\n\n"
+if options[:env]
+  rpc = {
+    :host			=> ENV['OA_RPC_HOST']			|| 'localhost',
+    :port			=> ENV['OA_RPC_PORT']			|| 8332,
+    :user			=> ENV['OA_RPC_USER']			|| '',
+    :password => ENV['OA_RPC_PASSWORD'] || '',
+    :schema		=> ENV['OA_RPC_SCHEMA']   || 'http'
+  }
+  config = {
+    :network	    => ENV['OA_NETWORK'] || 'mainnet',
+    :provider     => 'bitcoind',
+    :dust_limit   => (ENV['OA_DUST_LIMIT'] || 600).to_i,
+    :default_fees => (ENV['OA_DEFAULT_FEES'] || 10000).to_i,
+    :rpc					=> rpc
+  }
+elsif options[:config]
+  if !File.exists?(options[:config])
+    puts "File not found: #{options[:config]}"
+    exit(1)
+  end
+  config = JSON.parse(File.read(options[:config]), {symbolize_names: true})
+end
+
+if options[:verbose]
+  puts "using config:"
+  puts config.inspect
+end
+$oa = $api = OpenAssets::Api.new(config)
+
+command = ARGV.shift
+
+if command == 'console'
+  require "irb"
+  puts "API is available as $oa:"
+  IRB.start
+  puts "bye, bye"
+elsif command && $oa.respond_to?(command)
+  puts "running command '#{command}'"
+  puts $oa.send(command, *ARGV).inspect
+else
+  puts "use 'openassets --help' for help"
+end


### PR DESCRIPTION
This adds an openassets command line executable to the gem. It allows to run a IRB console or directly run certain commands (like get_balance).
config can either be loaded from ENV variables or a json file

examples:

    openassets -c config.json console - loads config from json file and starts an IRB console
    openassets -e get_balance - loads config from ENV parameters and executes the get_balance method