### PR TITLE
#17 [Propose] defining BitcoinCoreProvider public instance methods with help command result

### DIFF
--- a/spec/help-result.txt
+++ b/spec/help-result.txt
@@ -1,0 +1,121 @@
+== Blockchain ==
+getbestblockhash
+getblock "blockhash" ( verbosity )
+getblockchaininfo
+getblockcount
+getblockhash height
+getblockheader "hash" ( verbose )
+getchaintips
+getchaintxstats ( nblocks blockhash )
+getdifficulty
+getmempoolancestors txid (verbose)
+getmempooldescendants txid (verbose)
+getmempoolentry txid
+getmempoolinfo
+getrawmempool ( verbose )
+gettxout "txid" n ( include_mempool )
+gettxoutproof ["txid",...] ( blockhash )
+gettxoutsetinfo
+preciousblock "blockhash"
+pruneblockchain
+verifychain ( checklevel nblocks )
+verifytxoutproof "proof"
+
+== Control ==
+getinfo
+getmemoryinfo ("mode")
+help ( "command" )
+stop
+uptime
+
+== Generating ==
+generate nblocks ( maxtries )
+generatetoaddress nblocks address (maxtries)
+
+== Mining ==
+getblocktemplate ( TemplateRequest )
+getmininginfo
+getnetworkhashps ( nblocks height )
+prioritisetransaction <txid> <dummy value> <fee delta>
+submitblock "hexdata"  ( "dummy" )
+
+== Network ==
+addnode "node" "add|remove|onetry"
+clearbanned
+disconnectnode "[address]" [nodeid]
+getaddednodeinfo ( "node" )
+getconnectioncount
+getnettotals
+getnetworkinfo
+getpeerinfo
+listbanned
+ping
+setban "subnet" "add|remove" (bantime) (absolute)
+setnetworkactive true|false
+
+== Rawtransactions ==
+combinerawtransaction ["hexstring",...]
+createrawtransaction [{"txid":"id","vout":n},...] {"address":amount,"data":"hex",...} ( locktime ) ( replaceable )
+decoderawtransaction "hexstring"
+decodescript "hexstring"
+fundrawtransaction "hexstring" ( options )
+getrawtransaction "txid" ( verbose )
+sendrawtransaction "hexstring" ( allowhighfees )
+signrawtransaction "hexstring" ( [{"txid":"id","vout":n,"scriptPubKey":"hex","redeemScript":"hex"},...] ["privatekey1",...] sighashtype )
+
+== Util ==
+createmultisig nrequired ["key",...]
+estimatefee nblocks
+estimatesmartfee conf_target ("estimate_mode")
+signmessagewithprivkey "privkey" "message"
+validateaddress "address"
+verifymessage "address" "signature" "message"
+
+== Wallet ==
+abandontransaction "txid"
+abortrescan
+addmultisigaddress nrequired ["key",...] ( "account" )
+addwitnessaddress "address"
+backupwallet "destination"
+bumpfee "txid" ( options )
+dumpprivkey "address"
+dumpwallet "filename"
+getaccount "address"
+getaccountaddress "account"
+getaddressesbyaccount "account"
+getbalance ( "account" minconf include_watchonly )
+getnewaddress ( "account" )
+getrawchangeaddress
+getreceivedbyaccount "account" ( minconf )
+getreceivedbyaddress "address" ( minconf )
+gettransaction "txid" ( include_watchonly )
+getunconfirmedbalance
+getwalletinfo
+importaddress "address" ( "label" rescan p2sh )
+importmulti "requests" ( "options" )
+importprivkey "bitcoinprivkey" ( "label" ) ( rescan )
+importprunedfunds
+importpubkey "pubkey" ( "label" rescan )
+importwallet "filename"
+keypoolrefill ( newsize )
+listaccounts ( minconf include_watchonly)
+listaddressgroupings
+listlockunspent
+listreceivedbyaccount ( minconf include_empty include_watchonly)
+listreceivedbyaddress ( minconf include_empty include_watchonly)
+listsinceblock ( "blockhash" target_confirmations include_watchonly include_removed )
+listtransactions ( "account" count skip include_watchonly)
+listunspent ( minconf maxconf  ["addresses",...] [include_unsafe] [query_options])
+listwallets
+lockunspent unlock ([{"txid":"txid","vout":n},...])
+move "fromaccount" "toaccount" amount ( minconf "comment" )
+removeprunedfunds "txid"
+sendfrom "fromaccount" "toaddress" amount ( minconf "comment" "comment_to" )
+sendmany "fromaccount" {"address":amount,...} ( minconf "comment" ["address",...] replaceable conf_target "estimate_mode")
+sendtoaddress "address" amount ( "comment" "comment_to" subtractfeefromamount replaceable conf_target "estimate_mode")
+setaccount "address" "account"
+settxfee amount
+signmessage "address" "message"
+walletlock
+walletpassphrase "passphrase" timeout
+walletpassphrasechange "oldpassphrase" "newpassphrase"

--- a/spec/openassets/provider/bitcoin_core_provider_spec.rb
+++ b/spec/openassets/provider/bitcoin_core_provider_spec.rb
@@ -1,26 +1,92 @@
 require 'spec_helper'
 describe OpenAssets::Provider::BitcoinCoreProvider do
 
-  it 'undefined api call' do
-    provider = OpenAssets::Provider::BitcoinCoreProvider.new({})
-    expect(provider).to receive(:request).with(:getinfo)
-    provider.getinfo
+  context 'implicitly defined methods' do
+    it 'use getbalance' do
+      provider = OpenAssets::Provider::BitcoinCoreProvider.new({})
+      expect(provider).to receive(:request).with(:getbalance)
+      provider.getbalance
+    end
+
+    it 'implicitly defined' do
+      help_commands = File.read("#{File.dirname(__FILE__)}/../../help-result.txt").split("\n").inject([]) do |commands, line|
+        if !line.empty? && !line.start_with?('==')
+          commands << line.split(' ').first.to_sym
+        end
+        commands
+      end
+      expect(OpenAssets::Provider::BitcoinCoreProvider.public_instance_methods).to include *help_commands
+    end
   end
 
-  it 'use import_address' do
-    rest_client_mock = double('Rest Client')
-    config = {user: 'user', password: 'password', schema: 'https', port: '8332', host: 'localhost',timeout: 60 , open_timeout: 60}
-    provider = OpenAssets::Provider::BitcoinCoreProvider.new(config)
-    allow(RestClient::Request).to receive(:execute).and_return(rest_client_mock)
+  context 'explicitly defined methods' do
+    let(:rest_client_mock) do
+      rest_client_mock = double('Rest Client')
+      allow(RestClient::Request).to receive(:execute).and_return(rest_client_mock)
+      rest_client_mock
+    end
 
-    expect(RestClient::Request).to receive(:execute).with(:method => :post, :url => "https://user:password@localhost:8332", :timeout => 60, :open_timeout => 60, :payload => "{\"method\":\"importaddress\",\"params\":[\"address\"],\"id\":\"jsonrpc\"}", :headers => {:content_type=>:json})
-    provider.import_address(:address)
+    let(:provider) do
+      config = {user: 'user', password: 'password', schema: 'https', port: '8332', host: 'localhost',timeout: 60 , open_timeout: 60}
+      OpenAssets::Provider::BitcoinCoreProvider.new(config)
+    end
 
-    expect(provider).to receive(:post).with("https://user:password@localhost:8332", 60, 60, "{\"method\":\"importaddress\",\"params\":[\"address\"],\"id\":\"jsonrpc\"}", {:content_type=>:json})
-    provider.import_address(:address)
+    it 'use import_address' do
+      expect(RestClient::Request).to receive(:execute).with(:method => :post, :url => "https://user:password@localhost:8332", :timeout => 60, :open_timeout => 60, :payload => "{\"method\":\"importaddress\",\"params\":[\"address\"],\"id\":\"jsonrpc\"}", :headers => {:content_type=>:json})
+      provider.import_address(:address)
 
-    expect(provider).to receive(:request).with("importaddress", :address)
-    provider.import_address(:address)
+      expect(provider).to receive(:post).with("https://user:password@localhost:8332", 60, 60, "{\"method\":\"importaddress\",\"params\":[\"address\"],\"id\":\"jsonrpc\"}", {:content_type=>:json})
+      provider.import_address(:address)
+
+      expect(provider).to receive(:request).with(:importaddress, :address)
+      provider.import_address(:address)
+    end
+
+    it 'use list_unspent' do
+      expect(RestClient::Request).to receive(:execute).with(:method => :post, :url => "https://user:password@localhost:8332", :timeout => 60, :open_timeout => 60, :payload => "{\"method\":\"listunspent\",\"params\":[1,9999999,[]],\"id\":\"jsonrpc\"}", :headers => {:content_type=>:json})
+      provider.list_unspent
+
+      expect(provider).to receive(:post).with("https://user:password@localhost:8332", 60, 60, "{\"method\":\"listunspent\",\"params\":[1,9999999,[]],\"id\":\"jsonrpc\"}", {:content_type=>:json})
+      provider.list_unspent
+
+      expect(provider).to receive(:request).with(:listunspent, 1, 9999999, [])
+      provider.list_unspent
+    end
+
+    it 'use get_transaction' do
+      expect(RestClient::Request).to receive(:execute).with(:method => :post, :url => "https://user:password@localhost:8332", :timeout => 60, :open_timeout => 60, :payload => "{\"method\":\"getrawtransaction\",\"params\":[\"transaction_hash\",0],\"id\":\"jsonrpc\"}", :headers => {:content_type=>:json})
+      provider.get_transaction(:transaction_hash)
+
+      expect(provider).to receive(:post).with("https://user:password@localhost:8332", 60, 60, "{\"method\":\"getrawtransaction\",\"params\":[\"transaction_hash\",0],\"id\":\"jsonrpc\"}", {:content_type=>:json})
+      provider.get_transaction(:transaction_hash)
+
+      expect(provider).to receive(:request).with(:getrawtransaction, :transaction_hash, 0)
+      provider.get_transaction(:transaction_hash)
+    end
+
+    it 'use sign_transaction' do
+      allow(rest_client_mock).to receive(:[]).and_return(true, '01000000000000000000')
+
+      expect(RestClient::Request).to receive(:execute).with(:method => :post, :url => "https://user:password@localhost:8332", :timeout => 60, :open_timeout => 60, :payload => "{\"method\":\"signrawtransaction\",\"params\":[\"tx\"],\"id\":\"jsonrpc\"}", :headers => {:content_type=>:json})
+      provider.sign_transaction(:tx)
+
+      expect(provider).to receive(:post).with("https://user:password@localhost:8332", 60, 60, "{\"method\":\"signrawtransaction\",\"params\":[\"tx\"],\"id\":\"jsonrpc\"}", {:content_type=>:json}).and_return(rest_client_mock)
+      provider.sign_transaction(:tx)
+
+      expect(provider).to receive(:request).with(:signrawtransaction, :tx).and_return(rest_client_mock)
+      provider.sign_transaction(:tx)
+    end
+
+    it 'use send_transaction' do
+      expect(RestClient::Request).to receive(:execute).with(:method => :post, :url => "https://user:password@localhost:8332", :timeout => 60, :open_timeout => 60, :payload => "{\"method\":\"sendrawtransaction\",\"params\":[\"tx\"],\"id\":\"jsonrpc\"}", :headers => {:content_type=>:json})
+      provider.send_transaction(:tx)
+
+      expect(provider).to receive(:post).with("https://user:password@localhost:8332", 60, 60, "{\"method\":\"sendrawtransaction\",\"params\":[\"tx\"],\"id\":\"jsonrpc\"}", {:content_type=>:json})
+      provider.send_transaction(:tx)
+
+      expect(provider).to receive(:request).with(:sendrawtransaction, :tx)
+      provider.send_transaction(:tx)
+    end
   end
 
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,3 +43,12 @@ def load_block_mock(provider_mock)
     allow(provider_mock).to receive(:getblock).with(block_hash).and_return(json)
   end
 end
+
+class OpenAssets::Provider::BitcoinCoreProvider
+  alias_method :original_request, :request
+
+  def request(command, *params)
+    return File.read("#{File.dirname(__FILE__)}/help-result.txt") if command == :help
+    original_request(command, *params)
+  end
+end


### PR DESCRIPTION
getinfo is deprecated.

```
WARNING: getinfo is deprecated and will be fully removed in 0.16. Projects should transition to using getblockchaininfo, getnetworkinfo, and getwalletinfo before upgrading to 0.16
```

OpenAssets::Provider::BitcoinCoreProvider::RPC_API has :get_info.
By defining methods with help command result, RPC_API maintenance will become unnecessary.