### PR TITLE
MarkerOutput#to_payload supports binary metadata

### DIFF
--- a/lib/openassets/protocol/marker_output.rb
+++ b/lib/openassets/protocol/marker_output.rb
@@ -33,9 +33,7 @@ module OpenAssets
         @metadata ||= ''
         metadata_length = Bitcoin::Protocol.pack_var_int(@metadata.length).unpack("H*")
         payload << sort_count(metadata_length[0])
-        tmp = []
-        @metadata.bytes{|b| tmp << b.to_s(16)}
-        payload << tmp.join
+        payload << @metadata.bytes.map{|b| sprintf("%02x", b)}.join
         payload.join
       end
 

--- a/spec/openassets/protocol/marker_output_spec.rb
+++ b/spec/openassets/protocol/marker_output_spec.rb
@@ -9,6 +9,9 @@ describe OpenAssets::Protocol::MarkerOutput do
     no_metadata_payload = OpenAssets::Protocol::MarkerOutput.new([10000], nil).to_payload
     expect(no_metadata_payload).to eq('4f41010001904e00')
 
+    binary_metadata_payload = OpenAssets::Protocol::MarkerOutput.new([10000], "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f").to_payload
+    expect(binary_metadata_payload).to eq('4f41010001904e10000102030405060708090a0b0c0d0e0f')
+
     asset_quantities = []
     252.times {asset_quantities << 4}
     payload_252 = OpenAssets::Protocol::MarkerOutput.new(asset_quantities, '').to_payload


### PR DESCRIPTION
MarkerOutputのmetadataには任意のデータを設定することができますが、
バイナリ文字列である `"\x00\x01\x02\x03\x04\x05....\x0f`を設定したのち、to_payloadしたところ、以下のように1桁目に0がパディングされない結果となりました。

```
irb(main):004:0> OpenAssets::Protocol::MarkerOutput.new([10000], "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f").to_payload
=> "4f41010001904e100123456789abcdef"
```

`4f41010001904e10000102030405060708090a0b0c0d0e0f`のように0パディングされるように変更を加えました。
